### PR TITLE
Ensure removed probes are well removed from s3Pools map

### DIFF
--- a/probe/probe.go
+++ b/probe/probe.go
@@ -155,9 +155,8 @@ func (t *timer) Stop() {
 	}
 }
 
-// StartProbing start to probe the S3 endpoint
-func (p *Probe) StartProbing() error {
-	log.Println("Starting probing")
+func (p *Probe) PrepareProbing() error {
+	log.Println("Prepare probing")
 
 	if p.gateway {
 		err := p.prepareGatewayBucket()
@@ -177,6 +176,13 @@ func (p *Probe) StartProbing() error {
 			return err
 		}
 	}
+	return nil
+}
+
+
+// StartProbing start to probe the S3 endpoint
+func (p *Probe) StartProbing() error {
+	log.Println("Starting probing")
 
 	tickerProbe := newTimer(p.probeRatePerMin)
 	tickerDurabilityProbe := newTimer(p.durabilityProbeRatePerMin)

--- a/probe/probe_test.go
+++ b/probe/probe_test.go
@@ -78,12 +78,12 @@ func TestDurabilityLatencyCheckSuccess(t *testing.T) {
 	}
 }
 
-func TestStartProbingProperlyTerminate(t *testing.T) {
+func TestPrepareProbingProperlyTerminate(t *testing.T) {
 	probe, _ := getTestProbe()
 	suffix, _ := randomHex(8)
 	bucket := probe.latencyBucketName
 	probe.latencyBucketName = "/./??.."
-	err := probe.StartProbing()
+	err := probe.PrepareProbing()
 	if err == nil {
 		t.Errorf("Preparation errors are not properly handled: %s", err)
 	}
@@ -92,7 +92,7 @@ func TestStartProbingProperlyTerminate(t *testing.T) {
 
 	controlChan <- false
 
-	err = probe.StartProbing()
+	err = probe.PrepareProbing()
 	if err != nil {
 		t.Errorf("Probing is failing: %s", err)
 	}

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -2,6 +2,8 @@ package watcher
 
 import (
 	"fmt"
+	"github.com/smartystreets/assertions/assert"
+	"github.com/smartystreets/assertions/should"
 	"reflect"
 	"sort"
 	"testing"
@@ -95,5 +97,9 @@ func TestFlushOldProbesSendStopCommand(t *testing.T) {
 	w.flushOldProbes(s3ServicesFromStrings([]string{"test"}))
 	if len(controlChan) != 1 {
 		t.Errorf("Stop command not received")
+	}
+	result := assert.So(pools, should.NotContainKey, "test")
+	if result.Failed() {
+		t.Errorf("The assertion failed: %s", result)
 	}
 }


### PR DESCRIPTION
Currently when a service must be removed we well stop the probe but doesn't remove the service from the
s3Pools map.
This map is used to know which service is monitor. If for external reason thee service is a bit flaky in consul
the probe will be well removed and at thee next WatchPools check the service will still be seen as monitor by the probe.
So if it is again available in consul we do not recreate the probe leading to not monitored service.

Also during probe creation if for any reason we failed to prepare the probes (prepareLatencyBucket or prepareDurabilityBucket), the
probe is not well started and  never try to be started anymore